### PR TITLE
separate cycle for auxiliary PM sensor

### DIFF
--- a/softwarePico/libs/config.py
+++ b/softwarePico/libs/config.py
@@ -74,6 +74,7 @@ sensors = {
     'average_particle_measurements' : 20,
     'average_measurement_interval_ms' : 1000,
     'disable_sensors' : False,
+    'aux_pm_measure_s' : 3600, # 1 hour
 }
 sps30 = {
     'sensor_power_pin' : 1,

--- a/softwarePico/main.py
+++ b/softwarePico/main.py
@@ -39,6 +39,8 @@ while True:
         #sensors measurements with timestamp, they have been pre-heated for 30s
         sensors.measure(logger.now_DTF())
         sensors.shutdown()
+        # periodically take a comparison test measurement with the auxiliary sensor
+        sensors.measure_aux_pm_sensor()
         # check again if online, save data online, otherwise to file
         sent = False
         if wlan.initialize():


### PR DESCRIPTION
the battery requirement halves.
this is crucial since while maintaining the purpose of a secondary sensor as a reference in case of the first going nuts, we use them in different moments in time to limit the current peak. Also, the secondary sensor measures only once per sensors['aux_pm_measure_s'], thus reducing further the battery usage.