### PR TITLE
system can't continue if time isn't up to date, rebooting

### DIFF
--- a/softwarePico/main.py
+++ b/softwarePico/main.py
@@ -1,4 +1,5 @@
 from libs import config, cron, filelogger, logger, mqttlogger, sensors, wlan, datalogger
+from machine import reset
 
 logger.info('booting')
 #this test works also before initializing i2c and sensors
@@ -21,6 +22,10 @@ def updates():
                 if not cron.update_available:
                     cron.check_software_updates() # every update_interval
                 cron.software_update()
+        else:
+            logger.info("An update is required, but the sistem can't connect. Rebooting in 60s.")
+            cron.lightsleep_wrapper(60000)
+            reset()
         wlan.turn_off()
 
 def send_values():


### PR DESCRIPTION
if network is unreachable and the station can't update when required, better to reboot. Otherwise the measures will have a wrong datetime