### PR TITLE
implicit reload of config module vhen adding/updating a key/value

### DIFF
--- a/softwarePico/libs/config.py
+++ b/softwarePico/libs/config.py
@@ -194,20 +194,16 @@ def add(dictname, key, value, do_reload=True):
         result = _write_lines_to_file(me)
     if do_reload:
         if result:
-            return _reload()
+            _reload()
         else:
-            return sys.modules[__name__]
+            return
     else:
-        return result
+        return
 
 def _reload():
-    mod_name = __name__
-    del sys.modules[mod_name]
+    del sys.modules['libs.config']
     gc.collect()
-    if mod_name == 'config':
-        return __import__(mod_name)
-    else:
-        return __import__(mod_name).config
+    sys.modules['libs.config'] = __import__('libs.config').config
 
 def _new_dict(dictname,key,value):
     return [dictname + ' = {\n',

--- a/softwarePico/libs/config.py
+++ b/softwarePico/libs/config.py
@@ -3,7 +3,7 @@ aht20 = {
     'is_sensor' : True,
     'is_auxiliary' : False,
     'driver' : 'ahtx0',
-    'cls' : 'AHT10',
+    'cls' : 'AHT20',
     'init_arguments' : {},
     'i2c_address' : '0x38',
 }

--- a/softwarePico/libs/cron.py
+++ b/softwarePico/libs/cron.py
@@ -127,7 +127,8 @@ def check_software_updates():
             logger.info('Going to update from version ' + str(config.cron['current_version']) + 'to version ' + str(version.version))
         elif version.version == config.cron['current_version']:
             update_available = False
-        config.add('cron','last_update_check',time())
+        tt = time()
+        config.add('cron','last_update_check',tt)
     else:
         logger.warning("can't check for new software versions")
 
@@ -230,7 +231,8 @@ def restore_latest_timestamp():
 
 def store_latest_timestamp():
     global config
-    config.add('cron','latest_timestamp',time())
+    now = time()
+    config.add('cron','latest_timestamp',now)
     config.add('cron','deepsleep_reset',True)
 
 def lightsleep_wrapper(ms):

--- a/softwarePico/libs/cron.py
+++ b/softwarePico/libs/cron.py
@@ -127,7 +127,7 @@ def check_software_updates():
             logger.info('Going to update from version ' + str(config.cron['current_version']) + 'to version ' + str(version.version))
         elif version.version == config.cron['current_version']:
             update_available = False
-        config = config.add('cron','last_update_check',time())
+        config.add('cron','last_update_check',time())
     else:
         logger.warning("can't check for new software versions")
 
@@ -187,7 +187,7 @@ def software_update():
         # now update local version number
         if success:
             feed_wdt()
-            config = config.add('cron','current_version',version.version)
+            config.add('cron','current_version',version.version)
             logger.info("Version upgrade done! Upgraded to version " + str(version.version))
             update_available = False
             sleep_ms(1000)
@@ -226,12 +226,12 @@ def restore_latest_timestamp():
     if config.cron['deepsleep_reset']:
         latest = gmtime(config.cron['latest_timestamp']+4294)
         rtc.datetime(timetuple_to_rtctuple(latest))
-        config = config.add('cron','deepsleep_reset',False)
+        config.add('cron','deepsleep_reset',False)
 
 def store_latest_timestamp():
     global config
-    config = config.add('cron','latest_timestamp',time())
-    config = config.add('cron','deepsleep_reset',True)
+    config.add('cron','latest_timestamp',time())
+    config.add('cron','deepsleep_reset',True)
 
 def lightsleep_wrapper(ms):
     if config.cron['use_wdt']:

--- a/softwarePico/libs/datalogger.py
+++ b/softwarePico/libs/datalogger.py
@@ -12,6 +12,7 @@ UID = str(int(binascii.hexlify(iam).decode('utf-8'),16))
 def send_data(d):
     feed_wdt()
     gc.collect()
+    resp = None
     try:
         # if resp takes too long to arrive,
         resp = requests.post(config.datalogger['URL'], json=d, timeout=config.board['WDT_seconds']-0.5)
@@ -28,7 +29,7 @@ def send_data(d):
         # converting to integer (we assume that the server replies
         # with the new record ID if the insert succeded. An error message otherwise.
         int(resp.text)
-    except ValueError:
+    except (ValueError, AttributeError) as e:
         isInt = False
     return isInt
 

--- a/softwarePico/libs/leadacid.py
+++ b/softwarePico/libs/leadacid.py
@@ -76,8 +76,8 @@ def levels():
     # Restore normal power if battery is charging and level is greater than minimum safe lvl.
     if vvvoltage < safe_min_discharge:
         if config.leadacid['low_power_mode'] == False:
-            config = config.add('leadacid','low_power_mode',True)
+            config.add('leadacid','low_power_mode',True)
     if is_charging and (vvvoltage > safe_min_discharge + 0.1):
         if config.leadacid['low_power_mode'] == True:
-            config = config.add('leadacid','low_power_mode',False)
+            config.add('leadacid','low_power_mode',False)
     return temperature, percentage, vvvoltage, is_charging

--- a/softwarePico/libs/logger.py
+++ b/softwarePico/libs/logger.py
@@ -37,7 +37,7 @@ def nextLogFile():
 
 def updateLastlogConfig(n):
     global config, lastlog, logfile
-    config = config.add('logger','lastlog',n)
+    config.add('logger','lastlog',n)
     logfile = logfile_name + '.' + str(n)
     lastlog = n
     if logfile in os.listdir('/logs'):

--- a/softwarePico/libs/sensors.py
+++ b/softwarePico/libs/sensors.py
@@ -150,8 +150,11 @@ def measure(time_DTF):
         feed_wdt()   
         for measurand in ['temperature','humidity','barometric pressure','pm10','pm2.5','pm1.0','pm10_ch2','pm2.5_ch2','pm4_ch2','pm1.0_ch2']:
             measures[measurand] /= config.sensors['average_particle_measurements']
-        k = log(measures['humidity'] / 100) + (17.62 * measures['temperature']) / (243.12 + measures['temperature'])
-        measures['dew point'] =  243.12 * k / (17.62 - k)
+        if (measures['temperature'] != 0) and (measures['humidity'] != 0):
+            k = log(measures['humidity'] / 100) + (17.62 * measures['temperature']) / (243.12 + measures['temperature'])
+            measures['dew point'] =  243.12 * k / (17.62 - k)
+        else:
+            measures['dew point'] = 0
 
 def check_low_power():
     feed_wdt()

--- a/softwarePico/libs/sensors.py
+++ b/softwarePico/libs/sensors.py
@@ -106,7 +106,7 @@ def wakeup():
                 feed_wdt()
                 logger.info('Cleaning SPS30 sensor')
                 # this has to be written to file
-                config = config.add('sps30','last_cleaning',rtc_now)
+                config.add('sps30','last_cleaning',rtc_now)
         ### sps30 end custom wakeup code ###
         if not use_aux_sensors:
             power_i2c_devices(True,'off')
@@ -156,7 +156,7 @@ def measure(time_DTF):
 def check_low_power():
     feed_wdt()
     # checking for low power mode (battery saving)
-    if leadacid.config.leadacid['low_power_mode'] == True:
+    if config.leadacid['low_power_mode'] == True:
         leadacid.levels()
-        if leadacid.config.leadacid['low_power_mode'] == True:
+        if config.leadacid['low_power_mode'] == True:
             deepsleep_as_long_as_you_can()

--- a/softwarePico/libs/sensors.py
+++ b/softwarePico/libs/sensors.py
@@ -150,7 +150,7 @@ def measure(time_DTF):
         feed_wdt()   
         for measurand in ['temperature','humidity','barometric pressure','pm10','pm2.5','pm1.0','pm10_ch2','pm2.5_ch2','pm4_ch2','pm1.0_ch2']:
             measures[measurand] /= config.sensors['average_particle_measurements']
-        if (measures['temperature'] != 0) and (measures['humidity'] != 0):
+        if (measures['temperature'] != 0) or (measures['humidity'] != 0):
             k = log(measures['humidity'] / 100) + (17.62 * measures['temperature']) / (243.12 + measures['temperature'])
             measures['dew point'] =  243.12 * k / (17.62 - k)
         else:

--- a/softwarePico/libs/wlan.py
+++ b/softwarePico/libs/wlan.py
@@ -139,10 +139,10 @@ def serve_captive_portal():
                             wifiNumber += 1
                             ssid = "SSID_" + str(wifiNumber)
                             exist_wifi = ssid in config.wlan
-                        config = config.add('wlan',"SSID_" + str(wifiNumber),newssid)
-                        config = config.add('wlan',"PASSW_" + str(wifiNumber),newpassword)
-                        config = config.add('station',"latitude",latitude)
-                        config = config.add('station',"longitude",longitude)
+                        config.add('wlan',"SSID_" + str(wifiNumber),newssid)
+                        config.add('wlan',"PASSW_" + str(wifiNumber),newpassword)
+                        config.add('station',"latitude",latitude)
+                        config.add('station',"longitude",longitude)
                         # now send a confirmation page, wait ten seconds and reboot
                         #TODO
                         waiting_credentials = False

--- a/softwarePico/version.py
+++ b/softwarePico/version.py
@@ -1,9 +1,9 @@
-version = 28
+version = 31
 folders = ['/', '/libs', '/html', '/logs']
 #updates or new files. this file is manually updated and can only add or modify files or add folders
 updated_files = {
-    '/'     : ['main.py'], # there is no need to include version.py
-    '/libs' : ['ahtx0.py','bmp280.py','config.py','datalogger.py','mqttlogger.py','picosngcja5.py','qmc5883.py','sensors.py','sps30.py'],
+    '/'     : [], # there is no need to include version.py
+    '/libs' : ['config.py','cron.py','leadacid.py','logger.py','sensors.py','wlan.py'],
     '/html' : [],
 }
 # full update requires a list of all files

--- a/softwarePico/version.py
+++ b/softwarePico/version.py
@@ -1,9 +1,9 @@
-version = 31
+version = 33
 folders = ['/', '/libs', '/html', '/logs']
 #updates or new files. this file is manually updated and can only add or modify files or add folders
 updated_files = {
     '/'     : [], # there is no need to include version.py
-    '/libs' : ['config.py','cron.py','leadacid.py','logger.py','sensors.py','wlan.py'],
+    '/libs' : ['datalogger.py'],
     '/html' : [],
 }
 # full update requires a list of all files


### PR DESCRIPTION
the previous way of dealing with module reload was naive at best and caused the duplication of the config module. It led to odd things such the necessity to access some values from the config imported by another module instead of the config module itself.